### PR TITLE
Set the grid size according to the vtt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ You can run the file in any directory with .dd2vtt files. It will output a .png 
 ## How to use this script:
 
 1. Export your Dungoendraft map in the .dd2vtt format
+    - You should turn off Grid in the export as you want FGU to draw the grid, if the GM wishes
 2. Place the script/executable in the same folder as your .dd2vtt file (or files)
 3. Run the script (just double click on the executable)
 4. Voila! Your .png & .xml files have been created and are in the same folder. It will do this for all .dd2vtt files in the folder. 

--- a/draft2fgu.py
+++ b/draft2fgu.py
@@ -107,6 +107,10 @@ def convert_to_fgu(filename, input_path, output_path, portal_width, portal_lengt
 
         occluders.append(occluder)
 
+    gridsize = Element('gridsize')
+    gridsize.text = str(ppg) + ',' + str(ppg)
+    root.append(gridsize)
+
     with open(join(output_path, f'{filename}.xml'), 'wb') as f:
         f.write(tostring(root))
 


### PR DESCRIPTION
The VTT file contains the count of pixels per grid square.  Emit that data into the <gridsize> XML element so that FGU already has that populated.  The admin would still have to turn the grid on if they wished to see it within FGU.

Fixes issue #2 