### PR TITLE
Jpeg output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # draft2fgu
-Script to convert LOS data from Dungeondraft's .dd2vtt files to into a usable format for Fantasy Grounds Unity
+Script to convert LOS data from Dungeondraft's .dd2vtt files to into a usable format for Fantasy Grounds Unity (FGU)
 
 You can either convert individual files, or you can run the file in any directory with .dd2vtt files.
 
 ## How to (simply) use this script:
 
-1. Export your Dungoendraft map in the .dd2vtt format
+1. Export your Dungeondraft map in the .dd2vtt format
 2. Place the script/executable in the same folder as your .dd2vtt file (or files)
 3. Run the script (just double click on the executable)
 4. Voila! Your .png & .xml files have been created and are in the same folder. It will do this for all .dd2vtt files in the folder. 
@@ -48,6 +48,8 @@ optional arguments:
 
 If you specify filenames to convert, the output will be in the same directory as the input file, unless you have also specified `--output`.
 If you have specified filenames to convert, the `--input` parameter is ignored.
+
+If you do not specify any filenames to convert, this will scan the `INPUT` directory for `.dd2vtt` files.  If `INPUT` is not specified, the current directory will be used.
 
 Parameters specified on the command-line supercede those in the `config.txt` file described below.
 
@@ -114,3 +116,11 @@ Below are some valid examples of what you could put in the "config.txt" file
 	"portal_width":""
 }
 ```
+
+# Acknowledgements
+
+[Dungeondraft](https://dungeondraft.net/) is a map drawing tool.  Dungeondraft is produced by Megasploot.
+
+[Fantasy Grounds Unity](https://www.fantasygrounds.com) is a Virtual TableTop program for playing many different table-top Role Playing Games (TTRPG), virtually.  FGU is produced by SmiteWorks USA LLC.
+
+draft2vtt.py is not endorsed by either of these companies, it is a community-effort to make these two programs interoperable.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # draft2fgu
 Script to convert LOS data from Dungeondraft's .dd2vtt files to into a usable format for Fantasy Grounds Unity
 
-You can run the file in any directory with .dd2vtt files. It will output a .png file and a .xml file in the same directory. 
+You can either convert individual files, or you can run the file in any directory with .dd2vtt files.
 
-## How to use this script:
+## How to (simply) use this script:
 
 1. Export your Dungoendraft map in the .dd2vtt format
 2. Place the script/executable in the same folder as your .dd2vtt file (or files)
@@ -11,6 +11,45 @@ You can run the file in any directory with .dd2vtt files. It will output a .png 
 4. Voila! Your .png & .xml files have been created and are in the same folder. It will do this for all .dd2vtt files in the folder. 
 5. Place these in your "Fantasy Grounds\campaigns\{campaign name}\images" folder and import in FGU as normal.
 
+## Command-line
+```
+usage: draft2fgu.py [OPTIONS] [FILES]
+
+Convert Dungeondraft .dd2vtt files to .png/.xml for Fantasy Grounds Unity
+(FGU)
+
+positional arguments:
+  files                 Files to convert to .png + .xml for FGU
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -f, --force           Force overwrite destination files
+  -v, --verbose         Display progress
+  --version             show program's version number and exit
+  -i INPUT, --input INPUT
+                        Path to the input directory
+  -o OUTPUT, --output OUTPUT
+                        Path to the output directory
+  --portallength PORTALLENGTH
+                        Specify the length of portals
+  --portalwidth PORTALWIDTH
+                        Specify the width of portals
+```
+
+|Option          |Description|
+|----------------|-----------|
+| -f             | Overwrite the destination files even if they already exist |
+| -v             | Display the names of the converted files and some statistics |
+| -i INPUT       | Specify the directory to look in for *.dd2vtt files |
+| -o OUTPUT      | Specify the directory to write the output .png and .xml files |
+| --portallength | The additional length added to all doors in your map to overlap them with adjacent walls, so there is no LOS gap |
+| --portalwidth  | The depth of all doors in your map |
+| FILES          | The names of the files to convert |
+
+If you specify filenames to convert, the output will be in the same directory as the input file, unless you have also specified `--output`.
+If you have specified filenames to convert, the `--input` parameter is ignored.
+
+Parameters specified on the command-line supercede those in the `config.txt` file described below.
 
 ## Modifying the default behavior
 If you want to modify the default behavior, you can modify the parameters in the "config.txt" file:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ optional arguments:
   --version             show program's version number and exit
   -i INPUT, --input INPUT
                         Path to the input directory
+  --jpeg, --jpg         Write the image as a .jpg file
   -o OUTPUT, --output OUTPUT
                         Path to the output directory
   --portallength PORTALLENGTH
@@ -41,6 +42,7 @@ optional arguments:
 | -f             | Overwrite the destination files even if they already exist |
 | -v             | Display the names of the converted files and some statistics |
 | -i INPUT       | Specify the directory to look in for *.dd2vtt files |
+| --jpeg         | Also output the map as a .jpg file |
 | -o OUTPUT      | Specify the directory to write the output .png and .xml files |
 | --portallength | The additional length added to all doors in your map to overlap them with adjacent walls, so there is no LOS gap |
 | --portalwidth  | The depth of all doors in your map |

--- a/draft2fgu.py
+++ b/draft2fgu.py
@@ -1,13 +1,33 @@
+#!/usr/bin/env python3
+
+import argparse 
 from json import load, loads
 from base64 import decodebytes
 from xml.etree.ElementTree import Element, tostring
 from os import listdir, getcwd, path
 from os.path import isfile, join
+from pathlib import Path
+import sys
 from math import sin, cos
 
 
-def convert_to_fgu(filename, input_path, output_path, portal_width, portal_length):
-    with open(join(input_path, f'{filename}.dd2vtt')) as f:
+def convert_to_fgu(filename, output_path, portal_width, portal_length, force, verbose):
+    dd2vttPath = Path(filename)
+
+    if verbose:
+        print(f'Converting {dd2vttPath}')
+        
+    pngPath = Path.joinpath(output_path, filename.with_suffix('.png').name)
+    xmlPath = Path.joinpath(output_path, filename.with_suffix('.xml').name)
+    
+    if pngPath.exists() and not force:
+        print(f'Not overwriting {pngPath}', file=sys.stderr)
+        return
+    if xmlPath.exists() and not force:
+        print(f'Not overwriting {xmlPath}', file=sys.stderr)
+        return
+
+    with dd2vttPath.open(mode='r') as f:
         file = load(f)
 
     ppg = file['resolution']['pixels_per_grid']
@@ -20,7 +40,7 @@ def convert_to_fgu(filename, input_path, output_path, portal_width, portal_lengt
         elif string_val[-2:] == 'px':
             num = float(string_val[:-2]) / 2
         else:
-            raise ValueError("Invalid input")
+            raise ValueError('Invalid input')
         return num
 
     epsilon_w = parse_string_to_number(portal_width)
@@ -107,31 +127,109 @@ def convert_to_fgu(filename, input_path, output_path, portal_width, portal_lengt
 
         occluders.append(occluder)
 
-    with open(join(output_path, f'{filename}.xml'), 'wb') as f:
+    if verbose:
+        print('  {} occluders'.format(len(occluders)))
+
+    with xmlPath.open('wb') as f:
         f.write(tostring(root))
 
-    with open(join(output_path, f'{filename}.png'), 'wb') as f:
+    if verbose:
+        print(f'  Wrote {xmlPath}')
+
+    with pngPath.open('wb') as f:
         f.write(decodebytes(file['image'].encode('utf-8')))
 
+    if verbose:
+        print(f'  Wrote {pngPath}')
 
-input_path = getcwd()
-output_path = getcwd()
-portal_width = '25%'
-portal_length = '0px'
+def init_argparse() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        usage='%(prog)s [OPTIONS] [FILES]',
+        description='Convert Dungeondraft .dd2vtt files to .png/.xml for Fantasy Grounds Unity (FGU)'
+    )
+    parser.add_argument(
+        '-f', '--force', help='Force overwrite destination files', action='store_true'
+    )
+    parser.add_argument(
+        '-v', '--verbose', help='Display progress', action='store_true'
+    )
+    parser.add_argument(
+        '--version', action='version', version=f'{parser.prog} version 4.0.0'
+    )
+    parser.add_argument(
+        '-i', '--input', help='Path to the input directory'
+    )
+    parser.add_argument(
+        '-o', '--output', help='Path to the output directory'
+    )
+    parser.add_argument(
+        '--portallength', help='Specify the length of portals'
+    )
+    parser.add_argument(
+        '--portalwidth', help='Specify the width of portals'
+    )
 
-if path.exists('config.txt'):
-    with open('config.txt') as f:
-        config = loads(f.read().replace('\\', '/'))
+    parser.add_argument('files', nargs='*', help="Files to convert to .png + .xml for FGU")
+    return parser
 
-    if config.get('input_path', '') != '':
-        input_path = config['input_path']
-    if config.get('output_path', '') != '':
-        output_path = config['output_path']
-    if config.get('portal_width', '') != '':
-        portal_width = config['portal_width']
-    if config.get('portal_length', '') != '':
-        portal_length = config['portal_width']
+def main() -> None:
+    input_path = Path.cwd()
+    output_path = Path.cwd()
+    portal_width = '25%'
+    portal_length = '0px'
 
-dd2vtt_files = [f[:-7] for f in listdir(input_path) if f.endswith('.dd2vtt')]
-for filename in dd2vtt_files:
-    convert_to_fgu(filename, input_path, output_path, portal_width, portal_length)
+    configPath = Path('config.txt')
+    if configPath.exists():
+        with configPath.open(mode='r') as f:
+            config = loads(f.read().replace('\\', '/'))
+
+        if config.get('input_path', '') != '':
+            input_path = config['input_path']
+        if config.get('output_path', '') != '':
+            output_path = config['output_path']
+        if config.get('portal_width', '') != '':
+            portal_width = config['portal_width']
+        if config.get('portal_length', '') != '':
+            portal_length = config['portal_width']
+
+    parser = init_argparse()
+    args = parser.parse_args()
+
+    if args.input:
+        input_path = Path(args.input)
+    if args.output:
+        output_path = Path(args.output)
+    if args.portalwidth:
+        portal_width = args.portalwidth
+    if args.portallength:
+        portal_length = args.portallength
+
+    if input_path:
+        if not input_path.is_dir():
+            sys.exit( f'{input_path} is not a directory' )
+
+    if output_path:
+        if not output_path.is_dir():
+            sys.exit( f'{output_path} is not a directory' )
+
+    dd2vtt_files = []
+
+    if args.files:
+        for f in args.files:
+            if not output_path:
+                # Filename was specified, but no output_path
+                dd2vtt_files.append( (Path(f), Path(f).parent) )
+            else:
+                # Filename was specified and an output_path
+                dd2vtt_files.append( (Path(f), output_path))
+    else:
+        for f in input_path.iterdir():
+            if f.suffix == '.dd2vtt':
+                # Filename found in the input_path, send to the output_path
+                dd2vtt_files.append( (f, output_path) )
+
+    for filename, fileOutputPath in dd2vtt_files:
+        convert_to_fgu(filename, fileOutputPath, portal_width, portal_length, args.force, args.verbose)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Converts the png to a jpg using python's Pillow library.  The import isn't in the general block so that if you do not ask for a JPEG file, you won't be required to have the Pillow library installed.

Fixes #10 